### PR TITLE
Remove sorl thumbnails

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ psycopg2==2.7.3.1
 pytz==2017.3
 requests==2.18.4
 responses==0.7.0
-sorl-thumbnail==12.4.1
 statsd==3.2.1
 uwsgi==2.0.15
 whitenoise==3.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 100
+select = E,W,F,I,C
+exclude = *migrations/*

--- a/src/podcasts/settings.py
+++ b/src/podcasts/settings.py
@@ -35,7 +35,6 @@ INSTALLED_APPS = (
     'django.contrib.sitemaps',
     'rest_framework',
     'storages',
-    'sorl.thumbnail',
     'podcasts',
 )
 
@@ -115,8 +114,6 @@ else:
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     AWS_S3_SIGNATURE_VERSION = 's3v4'
     MEDIA_ROOT = ''
-
-THUMBNAIL_FORCE_OVERWRITE = True
 
 LOGGING = {
     'version': 1,

--- a/src/podcasts/utils/images.py
+++ b/src/podcasts/utils/images.py
@@ -1,9 +1,5 @@
-from sorl.thumbnail import get_thumbnail
-
-
 def get_thumbnail_url(image, size):
-    thumbnail = get_thumbnail(image, size, crop='center', quality=100, format="PNG")
-    image_url = thumbnail.url.replace(
+    image_url = image.url.replace(
         'https://s3.amazonaws.com',
         'https://s3.eu-west-3.amazonaws.com'
     )

--- a/src/podcasts/views.py
+++ b/src/podcasts/views.py
@@ -8,8 +8,6 @@ from podcasts.utils.images import get_thumbnail_url
 from podcasts.utils.stats import track_episode, track_podcast
 from podcasts.utils.time import pretty_date
 
-from sorl.thumbnail import get_thumbnail
-
 
 def health(request):
     """Return a 200 status code when the service is healthy.


### PR DESCRIPTION
TTFB is x3 or x4 because of it, even when using Redis (which initially I thought it caches the url there, but it seems it doesn't). Anyway having bigger images is still faster for now than using sorl.